### PR TITLE
Updated toArray implementation to include all errors

### DIFF
--- a/src/Weew/Validator/ValidationResult.php
+++ b/src/Weew/Validator/ValidationResult.php
@@ -66,7 +66,11 @@ class ValidationResult implements IValidationResult {
         $errors = [];
 
         foreach ($this->getErrors() as $error) {
-            $errors[$error->getSubject()] = $error->getMessage();
+            if ( ! array_has($errors, $error->getSubject())) {
+                $errors[$error->getSubject()] = [];
+            }
+
+            $errors[$error->getSubject()][] = $error->getMessage();
         }
 
         return $errors;

--- a/tests/Weew/Validator/ValidationResultTest.php
+++ b/tests/Weew/Validator/ValidationResultTest.php
@@ -82,8 +82,25 @@ class ValidationResultTest extends PHPUnit_Framework_TestCase {
 
         $this->assertEquals(
             [
-                'foo' => (new StringConstraint())->getMessage(),
-                'bar' => (new IntegerConstraint())->getMessage(),
+                'foo' => [(new StringConstraint())->getMessage()],
+                'bar' => [(new IntegerConstraint())->getMessage()],
+            ], $result->toArray()
+        );
+    }
+
+    public function test_to_array_multiple() {
+        $result = new ValidationResult();
+        $result->addErrors([
+            new ValidationError('foo', '', new StringConstraint()),
+            new ValidationError('foo', '', new IntegerConstraint()),
+        ]);
+
+        $this->assertEquals(
+            [
+                'foo' => [
+                    (new StringConstraint())->getMessage(),
+                    (new IntegerConstraint())->getMessage()
+                ],
             ], $result->toArray()
         );
     }


### PR DESCRIPTION
Instead of only including the last error per group in the toArray serialization, the validator result should contain all errors.